### PR TITLE
Update jitpack maven repo to azure repo

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -191,7 +191,8 @@ dependencyManagement {
 repositories {
   mavenLocal()
   mavenCentral()
-  maven { url 'https://jitpack.io' }
+  // update this to just the URL as we aren't publishing this as a library, we're publishing the container
+  maven { url 'https://pkgs.dev.azure.com/hmcts/Artifacts/_packaging/hmcts-lib/maven/v1' }
 }
 
 dependencies {


### PR DESCRIPTION
### Change description

The template project that I used was still referencing jitpack as the maven repo. I've updated it based on the instructions here:

https://hmcts.github.io/cloud-native-platform/common-pipeline/publishing-libraries/java.html#java

albeit without the credentials section as the build doesn't publish the maven artifact so  does not require credentials

### Testing done

Issue was a failed build of the master branch on the sandbox jenkins server, I've run the build for this branch and the jitpack gate is passing and the build is marked successful.

### Checklist

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
