### PR TITLE
Updated helm chart repo to oci://hmctspublic.azurecr.io/helm

### DIFF
--- a/charts/labs-hurricanepilot/Chart.yaml
+++ b/charts/labs-hurricanepilot/Chart.yaml
@@ -9,4 +9,4 @@ maintainers:
 dependencies:
   - name: java
     version: 5.3.0
-    repository: 'https://hmctspublic.azurecr.io/helm/v1/repo/'
+    repository: 'oci://hmctspublic.azurecr.io/helm'

--- a/charts/labs-hurricanepilot/Chart.yaml
+++ b/charts/labs-hurricanepilot/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.0"
 description: A Helm chart for labs-hurricanepilot App
 name: labs-hurricanepilot
 home: https://github.com/hmcts/labs-hurricanepilot
-version: 0.0.15
+version: 0.0.16
 maintainers:
   - name: HMCTS labs team
 dependencies:


### PR DESCRIPTION
### Change description

This aligns is with what I can see in fact-api, which I'm using for reference.

Jenkins was reporting this issue:

[2025-09-19T12:54:25.702Z] + helm dependency update charts/labs-hurricanepilot [2025-09-19T12:54:26.704Z] Error: can't get a valid version for 1 subchart(s): "java" (repository "https://hmctspublic.azurecr.io/helm/v1/repo/", version "5.3.0"). Make sure a matching chart version exists in the repo, or change the version constraint in Chart.yaml [2025-09-19T12:54:26.705Z] Getting updates for unmanaged Helm repositories... [2025-09-19T12:54:26.705Z] ...Successfully got an update from the "https://hmctspublic.azurecr.io/helm/v1/repo/" chart repository

### Testing done

jenkins pipeline for branch is passing.


### Checklist

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
